### PR TITLE
Add authentication and user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
 
+## Product Inventory
+
+This project demonstrates a simple CRUD interface for products using Materialize CSS for a Material Design look. It includes create, edit, and listing screens for managing product name, description, price, and quantity. Authentication allows users to register and log in, while an admin role can manage the user list.
+
 <p align="center">
 <a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class AuthController extends Controller
+{
+    public function showLoginForm(): View
+    {
+        return view('auth.login');
+    }
+
+    public function login(Request $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+            return redirect()->intended('/');
+        }
+
+        return back()->withErrors(['email' => 'Invalid credentials'])->onlyInput('email');
+    }
+
+    public function showRegisterForm(): View
+    {
+        return view('auth.register');
+    }
+
+    public function register(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|confirmed|min:8',
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => bcrypt($data['password']),
+            'role' => 'user',
+        ]);
+
+        Auth::login($user);
+        return redirect('/');
+    }
+
+    public function logout(Request $request): RedirectResponse
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect('/login');
+    }
+}

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ProductController extends Controller
+{
+    public function index(): View
+    {
+        $products = Product::all();
+        return view('products.index', compact('products'));
+    }
+
+    public function create(): View
+    {
+        return view('products.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'price' => 'required|numeric',
+            'quantity' => 'required|integer',
+        ]);
+
+        Product::create($data);
+        return redirect()->route('products.index');
+    }
+
+    public function edit(Product $product): View
+    {
+        return view('products.edit', compact('product'));
+    }
+
+    public function update(Request $request, Product $product): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'price' => 'required|numeric',
+            'quantity' => 'required|integer',
+        ]);
+
+        $product->update($data);
+        return redirect()->route('products.index');
+    }
+
+    public function destroy(Product $product): RedirectResponse
+    {
+        $product->delete();
+        return redirect()->route('products.index');
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class UserController extends Controller
+{
+    public function index(): View
+    {
+        $users = User::all();
+        return view('users.index', compact('users'));
+    }
+
+    public function edit(User $user): View
+    {
+        return view('users.edit', compact('user'));
+    }
+
+    public function update(Request $request, User $user): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email,'.$user->id,
+            'role' => 'required|string',
+        ]);
+
+        $user->update($data);
+        return redirect()->route('users.index');
+    }
+
+    public function destroy(User $user): RedirectResponse
+    {
+        $user->delete();
+        return redirect()->route('users.index');
+    }
+}

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (!Auth::check() || !Auth::user()->isAdmin()) {
+            abort(403);
+        }
+        return $next($request);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'price',
+        'quantity',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -44,5 +45,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Determine if the user has the admin role.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role === 'admin';
     }
 }

--- a/database/migrations/2024_01_01_000010_create_products_table.php
+++ b/database/migrations/2024_01_01_000010_create_products_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->integer('quantity');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/database/migrations/2024_01_01_000020_add_role_to_users_table.php
+++ b/database/migrations/2024_01_01_000020_add_role_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('user');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<h4>Login</h4>
+<form method="POST" action="{{ route('login') }}">
+    @csrf
+    <div class="input-field">
+        <input id="email" type="email" name="email" value="{{ old('email') }}" required autofocus>
+        <label for="email">Email</label>
+    </div>
+    <div class="input-field">
+        <input id="password" type="password" name="password" required>
+        <label for="password">Password</label>
+    </div>
+    <button type="submit" class="btn waves-effect waves-light">Login</button>
+</form>
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+<h4>Register</h4>
+<form method="POST" action="{{ route('register') }}">
+    @csrf
+    <div class="input-field">
+        <input id="name" type="text" name="name" value="{{ old('name') }}" required autofocus>
+        <label for="name">Name</label>
+    </div>
+    <div class="input-field">
+        <input id="email" type="email" name="email" value="{{ old('email') }}" required>
+        <label for="email">Email</label>
+    </div>
+    <div class="input-field">
+        <input id="password" type="password" name="password" required>
+        <label for="password">Password</label>
+    </div>
+    <div class="input-field">
+        <input id="password_confirmation" type="password" name="password_confirmation" required>
+        <label for="password_confirmation">Confirm Password</label>
+    </div>
+    <button type="submit" class="btn waves-effect waves-light">Register</button>
+</form>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Laravel') }}</title>
+    <!-- Materialize CSS -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+</head>
+<body>
+<nav>
+    <div class="nav-wrapper container">
+        <a href="{{ url('/') }}" class="brand-logo">{{ config('app.name', 'Laravel') }}</a>
+        <ul id="nav-mobile" class="right hide-on-med-and-down">
+            <li><a href="{{ route('products.index') }}">Products</a></li>
+            @auth
+                @if(auth()->user()->isAdmin())
+                    <li><a href="{{ route('users.index') }}">Users</a></li>
+                @endif
+                <li>
+                    <form action="{{ route('logout') }}" method="POST" style="display:inline">
+                        @csrf
+                        <button type="submit" class="btn-flat">Logout</button>
+                    </form>
+                </li>
+            @else
+                <li><a href="{{ route('login') }}">Login</a></li>
+                <li><a href="{{ route('register') }}">Register</a></li>
+            @endauth
+        </ul>
+    </div>
+</nav>
+<div class="container" style="margin-top: 20px;">
+    @yield('content')
+</div>
+<!-- Materialize JS -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+    <h4>Add Product</h4>
+    <form action="{{ route('products.store') }}" method="POST">
+        @csrf
+        <div class="input-field">
+            <input id="name" type="text" name="name" value="{{ old('name') }}" required>
+            <label for="name">Name</label>
+        </div>
+        <div class="input-field">
+            <textarea id="description" class="materialize-textarea" name="description">{{ old('description') }}</textarea>
+            <label for="description">Description</label>
+        </div>
+        <div class="input-field">
+            <input id="price" type="number" step="0.01" name="price" value="{{ old('price') }}" required>
+            <label for="price">Price</label>
+        </div>
+        <div class="input-field">
+            <input id="quantity" type="number" name="quantity" value="{{ old('quantity') }}" required>
+            <label for="quantity">Quantity</label>
+        </div>
+        <button type="submit" class="btn waves-effect waves-light">Save</button>
+    </form>
+@endsection

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+    <h4>Edit Product</h4>
+    <form action="{{ route('products.update', $product) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div class="input-field">
+            <input id="name" type="text" name="name" value="{{ old('name', $product->name) }}" required>
+            <label for="name" class="active">Name</label>
+        </div>
+        <div class="input-field">
+            <textarea id="description" class="materialize-textarea" name="description">{{ old('description', $product->description) }}</textarea>
+            <label for="description" class="active">Description</label>
+        </div>
+        <div class="input-field">
+            <input id="price" type="number" step="0.01" name="price" value="{{ old('price', $product->price) }}" required>
+            <label for="price" class="active">Price</label>
+        </div>
+        <div class="input-field">
+            <input id="quantity" type="number" name="quantity" value="{{ old('quantity', $product->quantity) }}" required>
+            <label for="quantity" class="active">Quantity</label>
+        </div>
+        <button type="submit" class="btn waves-effect waves-light">Update</button>
+    </form>
+@endsection

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="row">
+        <div class="col s12">
+            <a href="{{ route('products.create') }}" class="btn waves-effect waves-light">Add Product</a>
+        </div>
+    </div>
+    <table class="striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Price</th>
+                <th>Quantity</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($products as $product)
+                <tr>
+                    <td>{{ $product->id }}</td>
+                    <td>{{ $product->name }}</td>
+                    <td>{{ $product->price }}</td>
+                    <td>{{ $product->quantity }}</td>
+                    <td>
+                        <a href="{{ route('products.edit', $product) }}" class="btn-small">Edit</a>
+                        <form action="{{ route('products.destroy', $product) }}" method="POST" style="display:inline">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn-small red">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+<h4>Edit User</h4>
+<form method="POST" action="{{ route('users.update', $user) }}">
+    @csrf
+    @method('PUT')
+    <div class="input-field">
+        <input id="name" type="text" name="name" value="{{ old('name', $user->name) }}" required>
+        <label for="name">Name</label>
+    </div>
+    <div class="input-field">
+        <input id="email" type="email" name="email" value="{{ old('email', $user->email) }}" required>
+        <label for="email">Email</label>
+    </div>
+    <div class="input-field">
+        <select id="role" name="role">
+            <option value="user" {{ $user->role === 'user' ? 'selected' : '' }}>User</option>
+            <option value="admin" {{ $user->role === 'admin' ? 'selected' : '' }}>Admin</option>
+        </select>
+        <label for="role">Role</label>
+    </div>
+    <button type="submit" class="btn waves-effect waves-light">Update</button>
+</form>
+@endsection

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('content')
+<h4>Users</h4>
+<table class="striped">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($users as $user)
+        <tr>
+            <td>{{ $user->name }}</td>
+            <td>{{ $user->email }}</td>
+            <td>{{ $user->role }}</td>
+            <td>
+                <a href="{{ route('users.edit', $user) }}">Edit</a>
+                <form action="{{ route('users.destroy', $user) }}" method="POST" style="display:inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn-flat">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,18 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::resource('products', App\Http\Controllers\ProductController::class);
+
+Route::middleware('guest')->group(function () {
+    Route::get('/login', [App\Http\Controllers\AuthController::class, 'showLoginForm'])->name('login');
+    Route::post('/login', [App\Http\Controllers\AuthController::class, 'login']);
+    Route::get('/register', [App\Http\Controllers\AuthController::class, 'showRegisterForm'])->name('register');
+    Route::post('/register', [App\Http\Controllers\AuthController::class, 'register']);
+});
+
+Route::post('/logout', [App\Http\Controllers\AuthController::class, 'logout'])->name('logout');
+
+Route::middleware(['auth', App\Http\Middleware\AdminMiddleware::class])->group(function () {
+    Route::resource('users', App\Http\Controllers\UserController::class)->except(['create', 'show']);
+});


### PR DESCRIPTION
## Summary
- add role column migration and admin check
- implement AuthController and UserController for login/register and admin management
- create admin middleware and Materialize views for auth and user editing
- show auth links in layout and add routes for authentication & users
- document authentication & roles in README

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b5b1755c8321bdf9c556a41d0c18